### PR TITLE
fix pr-commit relationship

### DIFF
--- a/lib/githubProcessor.js
+++ b/lib/githubProcessor.js
@@ -273,7 +273,7 @@ class GitHubProcessor {
       // to form a PR nor is the origin repo in our filter set. So, keep the commit as PR-specific.  The commit itself
       // may or may not be fetched depending on filtering.  This may duplicate the commits in the output but fetching from
       // GitHub will be deduplicated as the commit URLs are the same.
-      this._addRelation(request, 'pull_request_commits', 'commit', document._links.commits.href);
+      this._addCollection(request, 'pull_request_commits', 'commit', document._links.commits.href);
     }
 
     // link and queue the related issue.  Getting the issue will bring in the comments for this PR
@@ -765,8 +765,7 @@ class GitHubProcessor {
     request.linkResource(relation.origin, `${qualifier}`);
     request.linkSiblings(`${relation.qualifier}:pages`);
     request.linkCollection('unique', `${relation.qualifier}:pages:${relation.guid}`);
-    const id = relation.type === 'commit' ? 'sha' : 'id';
-    const urns = document.elements.map(element => `urn:${relation.type}:${element[id]}`);
+    const urns = document.elements.map(element => `urn:${relation.type}:${element.id}`);
     request.linkResource('resources', urns);
     return document;
   }

--- a/lib/githubProcessor.js
+++ b/lib/githubProcessor.js
@@ -269,8 +269,11 @@ class GitHubProcessor {
     }
 
     if (document._links.commits && document.commits) {
-      // TODO.  look at PR commit to see if it should be shared with the repo commit (use a relation if shared)
-      this._addRelation(request, 'commits', 'commit', document._links.commits.href);
+      // PR commits are not necessarily in this repo.  Unfortunately, they do not include explicit repo info we can use
+      // to form a PR nor is the origin repo in our filter set. So, keep the commit as PR-specific.  The commit itself
+      // may or may not be fetched depending on filtering.  This may duplicate the commits in the output but fetching from
+      // GitHub will be deduplicated as the commit URLs are the same.
+      this._addRelation(request, 'pull_request_commits', 'commit', document._links.commits.href);
     }
 
     // link and queue the related issue.  Getting the issue will bring in the comments for this PR
@@ -616,7 +619,7 @@ class GitHubProcessor {
 
   isCollectionType(request) {
     const collections = new Set([
-      'collaborators', 'commit_comments', 'commits', 'contributors', 'events', 'issues', 'issue_comments', 'members', 'orgs', 'repos', 'reviews', 'review_comments', 'subscribers', 'stargazers', 'statuses', 'teams'
+      'collaborators', 'commit_comments', 'commits', 'contributors', 'events', 'issues', 'issue_comments', 'members', 'orgs', 'repos', 'reviews', 'review_comments', 'pull_request_commits', 'subscribers', 'stargazers', 'statuses', 'teams'
     ]);
     return collections.has(request.type);
   }
@@ -762,7 +765,8 @@ class GitHubProcessor {
     request.linkResource(relation.origin, `${qualifier}`);
     request.linkSiblings(`${relation.qualifier}:pages`);
     request.linkCollection('unique', `${relation.qualifier}:pages:${relation.guid}`);
-    const urns = document.elements.map(element => `urn:${relation.type}:${element.id}`);
+    const id = relation.type === 'commit' ? 'sha' : 'id';
+    const urns = document.elements.map(element => `urn:${relation.type}:${element[id]}`);
     request.linkResource('resources', urns);
     return document;
   }

--- a/lib/visitorMap.js
+++ b/lib/visitorMap.js
@@ -190,7 +190,7 @@ const pull_request = {
   reviews: review,
   review_comments: review_comment,
   statuses: collection(status),
-  commits: collection(commit),
+  pull_request_commits: collection(commit),
   issue: issue,
   issue_comments: collection(issue_comment)
 };
@@ -243,6 +243,11 @@ const org = {
   user: user,
   members: relation(user),
   teams: relation(team)
+};
+
+const orgs = {
+  _type: 'orgs',
+  orgs: collection(org)
 };
 
 function event(additions = {}) {
@@ -319,6 +324,7 @@ const events = {
 const entities = {
   self: self,
   neighbors: neighbors,
+  orgs: orgs,
   org: org,
   repo: repo,
   user: user,


### PR DESCRIPTION
* changed pullrequest to have a collection of commits rather than a relation (revert a change from a few days ago)
* make the commits collection pull-request specific (i.e., pull_request_commits)

Note that the individual commit objects are still of type "commit", not pull_request_commit.  I think that still makes sense.
