### PR TITLE
update request deferral handling

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -19,6 +19,7 @@ class Crawler {
     this.logger = options.logger;
     this.counter = 0;
     this.counterRollover = Number.parseInt('zzz', 36);
+    this.deferring = false;
   }
 
   _reconfigure(current, changes) {
@@ -370,6 +371,11 @@ class Crawler {
   _logOutcome(request) {
     const outcome = request.outcome ? request.outcome : 'Processed';
     request.addMeta({ time: Date.now() - request.start });
+    // If this request is deferred, and we've already logged that info, return.
+    if (request.isDeferred() && this.deferring) {
+      return request;
+    }
+    this.deferring = request.isDeferred();
     this.logger.info(`${outcome} ${request.type}@${request.url} ${request.message || ''}`, request.meta);
     return request;
   }

--- a/lib/githubFetcher.js
+++ b/lib/githubFetcher.js
@@ -120,9 +120,9 @@ class GitHubFetcher {
   }
 
   _handleDeferred(request, benchTime) {
+    request.delay(this.options.deferDelay || 500);  // add a little delay to this loop just to tame things a bit.
     const delay = benchTime - Date.now();
     request.addMeta({ deferDelay: delay });
-    request.delay(200);  // add a little delay to this loop just to tame things a bit.
     return request.markDefer('Deferred ', `Deferring ${delay}ms for a token`);
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -216,6 +216,10 @@ class Request {
     return this.processControl === 'skip' || this.processControl === 'requeue' || this.processControl === 'defer';
   }
 
+  isDeferred() {
+    return this.processControl === 'defer';
+  }
+
   delayUntil(time) {
     if (!this.nextRequestTime || this.nextRequestTime < time) {
       this.nextRequestTime = time;

--- a/test/gitHubProcessorTests.js
+++ b/test/gitHubProcessorTests.js
@@ -458,7 +458,7 @@ describe('Pull Request processing', () => {
       repo: { href: 'urn:repo:17', type: 'resource' },
       reviews: { href: 'urn:repo:12:pull_request:13:reviews', type: 'collection' },
       review_comments: { href: 'urn:repo:12:pull_request:13:review_comments', type: 'collection' },
-      commits: { href: 'urn:repo:12:pull_request:13:commits:pages:*', type: 'relation' },
+      pull_request_commits: { href: 'urn:repo:12:pull_request:13:pull_request_commits', type: 'collection' },
       statuses: { href: 'urn:repo:12:commit:funkySHA:statuses', type: 'collection' },
       issue: { href: 'urn:repo:12:issue:13', type: 'resource' },
       issue_comments: { href: 'urn:repo:12:issue:13:issue_comments', type: 'collection' }
@@ -474,7 +474,7 @@ describe('Pull Request processing', () => {
       { type: 'reviews', url: 'http://pull_request/13/reviews', qualifier: 'urn:repo:12:pull_request:13', path: '/reviews' },
       { type: 'review_comments', url: 'http://review_comments', qualifier: 'urn:repo:12:pull_request:13', path: '/review_comments' },
       { type: 'statuses', url: 'http://statuses/funkySHA', qualifier: 'urn:repo:12:pull_request:13', path: '/statuses' },
-      { type: 'commits', url: 'http://commits', qualifier: 'urn:repo:12:pull_request:13', path: '/commits' }
+      { type: 'pull_request_commits', url: 'http://commits', qualifier: 'urn:repo:12:pull_request:13', path: '/pull_request_commits' }
     ];
     expectQueued(queue, expected);
   });


### PR DESCRIPTION
improve the logging of request deferrals.  Mostly just log only the first transition to a deferal so the log is not flooded when the tokens all expire.