### PR TITLE
change PR - commit to relation

### DIFF
--- a/lib/githubProcessor.js
+++ b/lib/githubProcessor.js
@@ -13,7 +13,7 @@ const uuid = require('node-uuid');
 class GitHubProcessor {
   constructor(store) {
     this.store = store;
-    this.version = 11;
+    this.version = 12;
   }
 
   process(request) {
@@ -202,8 +202,18 @@ class GitHubProcessor {
   commit(request) {
     const document = request.document;
     const context = request.context;
-    request.addSelfLink('sha');
-    request.linkSiblings(`${context.qualifier}:commits`);
+    let repoUrn = null;
+    if (context.qualifier.includes('pull_request')) {
+      // if this is a PR commit, put it in a central spot for the repo and setup the qualifier so comments go there too
+      repoUrn = `urn:repo:${context.qualifier.split(':')[2]}`;
+      context.qualifier = `${repoUrn}:pull_request_commit`;
+      request.linkResource('self', `${context.qualifier}:${document.sha}`);
+    } else {
+      request.addSelfLink('sha');
+      repoUrn = context.qualifier;
+      request.linkSiblings(`${context.qualifier}:commits`);
+    }
+    this._addRoot(request, 'repo', 'repo', document.url.replace(/\/commits\/.*/, ''), repoUrn);
 
     // Most often there actually are no comments. Get the comments if we think there will be some and this resource is being processed (vs. traversed).
     // Note that if we are doing event processing, new comments will be added to the list dynamically so the only reason we need to refetch the
@@ -215,7 +225,7 @@ class GitHubProcessor {
       // even if there are no comments to process, add a link to the comment collection for future use
       request.linkCollection('commit_comments', commentsUrn);
     }
-    this._addRoot(request, 'repo', 'repo', document.url.replace(/\/commits\/.*/, ''), `${context.qualifier}`);
+
     // TODO some commits have author and committer properties, others have email info in a "commit" property
     // For the former, this code works.  For the latter, consider queuing an email lookup and storing a
     // email key here for the author/committer.
@@ -269,11 +279,7 @@ class GitHubProcessor {
     }
 
     if (document._links.commits && document.commits) {
-      // PR commits are not necessarily in this repo.  Unfortunately, they do not include explicit repo info we can use
-      // to form a PR nor is the origin repo in our filter set. So, keep the commit as PR-specific.  The commit itself
-      // may or may not be fetched depending on filtering.  This may duplicate the commits in the output but fetching from
-      // GitHub will be deduplicated as the commit URLs are the same.
-      this._addCollection(request, 'pull_request_commits', 'commit', document._links.commits.href);
+      this._addRelation(request, 'commits', 'commit', document._links.commits.href);
     }
 
     // link and queue the related issue.  Getting the issue will bring in the comments for this PR
@@ -619,7 +625,7 @@ class GitHubProcessor {
 
   isCollectionType(request) {
     const collections = new Set([
-      'collaborators', 'commit_comments', 'commits', 'contributors', 'events', 'issues', 'issue_comments', 'members', 'orgs', 'repos', 'reviews', 'review_comments', 'pull_request_commits', 'subscribers', 'stargazers', 'statuses', 'teams'
+      'collaborators', 'commit_comments', 'commits', 'contributors', 'events', 'issues', 'issue_comments', 'members', 'orgs', 'repos', 'reviews', 'review_comments', 'subscribers', 'stargazers', 'statuses', 'teams'
     ]);
     return collections.has(request.type);
   }
@@ -765,7 +771,8 @@ class GitHubProcessor {
     request.linkResource(relation.origin, `${qualifier}`);
     request.linkSiblings(`${relation.qualifier}:pages`);
     request.linkCollection('unique', `${relation.qualifier}:pages:${relation.guid}`);
-    const urns = document.elements.map(element => `urn:${relation.type}:${element.id}`);
+    const id = relation.type === 'commit' ? 'sha' : 'id';
+    const urns = document.elements.map(element => `urn:${relation.type}:${element[id]}`);
     request.linkResource('resources', urns);
     return document;
   }

--- a/lib/githubProcessor.js
+++ b/lib/githubProcessor.js
@@ -184,7 +184,7 @@ class GitHubProcessor {
 
     this._addRelation(request, 'teams', 'team');
     // this._addRelation(request, 'collaborators', 'user', document.collaborators_url.replace('{/collaborator}', ''));
-    this._addRelation(request, 'collaborators', 'user', document.collaborators_url.replace('{/collaborator}', '?affiliation=outside'));
+    this._addRelation(request, 'collaborators', 'user', document.collaborators_url.replace('{/collaborator}', '?affiliation=direct'));
     this._addRelation(request, 'contributors', 'user');
     if (document.subscribers_count) {
       this._addRelation(request, 'subscribers', 'user');

--- a/lib/githubProcessor.js
+++ b/lib/githubProcessor.js
@@ -771,8 +771,9 @@ class GitHubProcessor {
     request.linkResource(relation.origin, `${qualifier}`);
     request.linkSiblings(`${relation.qualifier}:pages`);
     request.linkCollection('unique', `${relation.qualifier}:pages:${relation.guid}`);
+    const urnPrefix = relation.type === 'commit' && qualifier.includes('pull_request') ? `repo:${qualifier.split(':')[2]}:pull_request_commit` : relation.type;
     const id = relation.type === 'commit' ? 'sha' : 'id';
-    const urns = document.elements.map(element => `urn:${relation.type}:${element[id]}`);
+    const urns = document.elements.map(element => `urn:${urnPrefix}:${element[id]}`);
     request.linkResource('resources', urns);
     return document;
   }

--- a/lib/traversalPolicy.js
+++ b/lib/traversalPolicy.js
@@ -128,6 +128,10 @@ class TraversalPolicy {
     return new TraversalPolicy('originOnly', 'always', TraversalPolicy._resolveMapSpec(map));
   }
 
+  static reprocessAlways(map) {
+    return new TraversalPolicy('storageOnly', 'always', TraversalPolicy._resolveMapSpec(map));
+  }
+
   static clone(policy) {
     return new TraversalPolicy(policy.fetch, policy.freshness, policy.map);
   }

--- a/lib/visitorMap.js
+++ b/lib/visitorMap.js
@@ -190,7 +190,7 @@ const pull_request = {
   reviews: review,
   review_comments: review_comment,
   statuses: collection(status),
-  pull_request_commits: collection(commit),
+  commits: collection(commit),
   issue: issue,
   issue_comments: collection(issue_comment)
 };

--- a/test/gitHubProcessorTests.js
+++ b/test/gitHubProcessorTests.js
@@ -458,7 +458,7 @@ describe('Pull Request processing', () => {
       repo: { href: 'urn:repo:17', type: 'resource' },
       reviews: { href: 'urn:repo:12:pull_request:13:reviews', type: 'collection' },
       review_comments: { href: 'urn:repo:12:pull_request:13:review_comments', type: 'collection' },
-      pull_request_commits: { href: 'urn:repo:12:pull_request:13:pull_request_commits', type: 'collection' },
+      commits: { href: 'urn:repo:12:pull_request:13:commits:pages:*', type: 'relation' },
       statuses: { href: 'urn:repo:12:commit:funkySHA:statuses', type: 'collection' },
       issue: { href: 'urn:repo:12:issue:13', type: 'resource' },
       issue_comments: { href: 'urn:repo:12:issue:13:issue_comments', type: 'collection' }
@@ -474,7 +474,7 @@ describe('Pull Request processing', () => {
       { type: 'reviews', url: 'http://pull_request/13/reviews', qualifier: 'urn:repo:12:pull_request:13', path: '/reviews' },
       { type: 'review_comments', url: 'http://review_comments', qualifier: 'urn:repo:12:pull_request:13', path: '/review_comments' },
       { type: 'statuses', url: 'http://statuses/funkySHA', qualifier: 'urn:repo:12:pull_request:13', path: '/statuses' },
-      { type: 'pull_request_commits', url: 'http://commits', qualifier: 'urn:repo:12:pull_request:13', path: '/pull_request_commits' }
+      { type: 'commits', url: 'http://commits', qualifier: 'urn:repo:12:pull_request:13', path: '/commits' }
     ];
     expectQueued(queue, expected);
   });


### PR DESCRIPTION
OK.  this should be the final one.  Summary

* PRs now have a **relation** to their commits
* all PR commits for a repo have an identity of urn:repo:NNN:pull_request_commit:<sha>.  That is, they are shared
* comments for PR commits are relative to their commit

For bonus marks, this PR changes the repo collaborators to use the new "direct" flag