### PR TITLE
fix mongo fetch from storage

### DIFF
--- a/lib/githubFetcher.js
+++ b/lib/githubFetcher.js
@@ -144,19 +144,28 @@ class GitHubFetcher {
     const start = Date.now();
     return this.store.get(request.type, request.url).then(
       document => {
+        if (!document) {
+          return this._fetchMissing(request);
+        }
         request.addMeta({ read: Date.now() - start });
         request.response = { headers: {} };
         return this._prepareCachedRequest(request, document, 'storage');
       },
       error => {
-        // The doc could not be loaded from storage. Either storage has failed somehow or this
-        // is a new processing path. Rethrow the error, or use the origin store, respectively.
-        const missing = request.policy.shouldFetchMissing(request);
-        if (!missing) {
-          return request.markSkip('Unreachable for reprocessing');
-        }
-        return this._fetchFromGitHub(request, false);
+        // TODO eating the error here. need to decide what's best as some stores might throw an
+        // error to signal missing.
+        return this._fetchMissing(request);
       });
+  }
+
+  _fetchMissing(request) {
+    // The doc could not be loaded from storage. Either storage has failed somehow or this
+    // is a new processing path. Decide if we should use the origin store, or skip.
+    const missing = request.policy.shouldFetchMissing(request);
+    if (missing) {
+      return this._fetchFromGitHub(request, false);
+    }
+    return request.markSkip('Unreachable for reprocessing');
   }
 
   _checkGitHubRateLimit(request, response) {


### PR DESCRIPTION
turns out that mongo return null from a fetch of a non-existant doc whereas the azure storage was throwing an error.