### PR TITLE
handle fallback traits for some request types

### DIFF
--- a/lib/githubFetcher.js
+++ b/lib/githubFetcher.js
@@ -213,7 +213,7 @@ class GitHubFetcher {
 
   _getToken(request) {
     const traits = this._getTypeDetails(request.type).tokenTraits || [];
-    const additionalTraits = [];
+    let additionalTraits = [];
     if (request.context.repoType) {
       additionalTraits.push(request.context.repoType);
     }
@@ -221,7 +221,8 @@ class GitHubFetcher {
       // if this is a retry, elevate the token to avoid any permissions issues
       additionalTraits.push('private', 'admin');
     }
-    return this.tokenFactory.getToken(traits.concat(additionalTraits)).then(token => {
+    additionalTraits = additionalTraits.length === 0 ? [] : [additionalTraits];
+    return this.tokenFactory.getToken(additionalTraits.concat(traits)).then(token => {
       if (token === null) {
         throw new Error(`No API tokens available for ${request.toString()}`);
       }
@@ -265,15 +266,14 @@ class GitHubFetcher {
   _getTypeDetails(type) {
     const result = {
       orgs: { tokenTraits: ['admin'] },
-      org: { tokenTraits: ['admin'] },
-      repos: { tokenTraits: ['admin'] },
-      repo: { tokenTraits: ['admin'] },
+      org: { tokenTraits: [['admin'], ['public']] },
+      repos: { tokenTraits: [['admin'], ['public']] },
+      repo: { tokenTraits: [['admin'], ['public']] },
       teams: { tokenTraits: ['admin'] },
       team: { tokenTraits: ['admin'] },
       members: { tokenTraits: ['admin'] },
       update_events: { tokenTraits: ['admin'] },
       events: { tokenTraits: ['admin'] },
-      // collaborators: { tokenTraits: ['push'] },
       collaborators: { tokenTraits: ['admin'], headers: { Accept: 'application/vnd.github.korra-preview' } },
       reviews: { headers: { Accept: 'application/vnd.github.black-cat-preview+json' } },
       review: { headers: { Accept: 'application/vnd.github.black-cat-preview+json' } },


### PR DESCRIPTION
this is to handle cases where we only have public tokens.  We want to use elevated tokens if we have them but fall back to public tokens if not