### PR TITLE
improve event processing

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -143,7 +143,7 @@ class Crawler {
 
 
   _acquireLock(request) {
-    if (!request.url || !this.locker) {
+    if (!request.url || !this.locker || request.requiresLock === false) {
       return Q(request);
     }
     const self = this;

--- a/lib/githubProcessor.js
+++ b/lib/githubProcessor.js
@@ -416,6 +416,17 @@ class GitHubProcessor {
 
   // ===============  Event Processors  ============
 
+  // An event in a repo or org has been detected. Queue up a request to update the events for
+  // the affected entity.  This event typically comes straight off the event feed and so is not
+  // deduplicated.  By queuing it here, the hard work of getting the events etc is deduplicated.
+  // This dramatically reduces the work as events in one repo tend to come in bursts.
+  event_trigger(request) {
+    request.markNoSave();
+    const newRequest = new Request('update_events', request.url, request.context);
+    request.queueRequests(newRequest, 'immediate');
+    return null;
+  }
+
   // The events in a repo or org have changed.  Go get the latest events, discover any new
   // ones and queue them for processing.
   update_events(request) {
@@ -430,7 +441,7 @@ class GitHubProcessor {
         // Events are immutable (and we can't fetch them later) so set the etag to a constant
         const baseUrl = request.url.split("?")[0];
         const newRequest = new Request(event.type, `${baseUrl}/${event.id}`);
-        newRequest.policy = TraversalPolicy.events();
+        newRequest.policy = TraversalPolicy.event(event.type);
         newRequest.payload = { etag: 1, body: event };
         return newRequest;
       });

--- a/lib/queueSet.js
+++ b/lib/queueSet.js
@@ -16,13 +16,13 @@ class QueueSet {
     this.deadletter = deadletter;
     this.options = options;
     this.options._config.on('changed', this._reconfigure.bind(this));
-    this.startMap = this._createStartMap(this.options.weights || [1]);
+    this.startMap = this._createStartMap(this.options.weights);
     this.popCount = 0;
   }
 
   _reconfigure(current, changes) {
-    if (changes.some(patch => patch.path === '/weights')) {
-      this._startMap = this._createStartMap(this.options.weights || [1]);
+    if (changes.some(patch => patch.path.includes('/weights'))) {
+      this._startMap = this._createStartMap(this.options.weights);
     }
     return Q();
   }
@@ -94,17 +94,14 @@ class QueueSet {
   }
 
   _createStartMap(weights) {
-    if (this.queues.length < weights.length) {
-      throw new Error('Cannot have more weights than queues');
-    }
+    // Create a simple table of which queue to pop based on the weights supplied.  For each queue,
+    // look up its weight and add that many entries in the map.  If no weight is included, assume 1.
     const result = [];
-    for (let i = 0; i < weights.length; i++) {
-      for (let j = 0; j < weights[i]; j++) {
+    for (let i = 0; i < this.queues.length; i++) {
+      const count = weights[this.queues[i].getName()] || 1;
+      for (let j = 0; j < count; j++) {
         result.push(i);
       }
-    }
-    if (result.length === 0) {
-      throw new Error('Weights must not be empty');
     }
     return result;
   }

--- a/lib/traversalPolicy.js
+++ b/lib/traversalPolicy.js
@@ -48,8 +48,6 @@ Reprocess and Update -- Reprocess anything that is EITHER older version or out o
 * fetch = originStorage
 * freshness = matchOrVersion
 
-
-
 A policy spec is of the form
   <policyName>[:mapSpec]
   mapSpec :: [scenario/]mapName[@p/a/t/h]
@@ -101,6 +99,10 @@ class TraversalPolicy {
   }
 
   static default(map) {
+    return new TraversalPolicy('mutables', 'match', TraversalPolicy._resolveMapSpec(map));
+  }
+
+  static event(map) {
     return new TraversalPolicy('mutables', 'match', TraversalPolicy._resolveMapSpec(map));
   }
 


### PR DESCRIPTION
change event processing to immediately queue new event triggers for repos and orgs rather then immediately fetching their events.  This allows for deduplication when a mess of events happen for one entity.

Also improve queue weight management