### PR TITLE
add root request to log meta object

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -127,7 +127,7 @@
         "CRAWLER_MODE": "Standard",
         "CRAWLER_EVENT_PROVIDER": "none",
         "CRAWLER_OPTIONS_PROVIDER": "redis",
-        "DEBUG.off": "amqp10:client,amqp10:link:receiver"
+        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
       },
       "console": "internalConsole",
       "sourceMaps": false,

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -234,7 +234,7 @@ class Crawler {
           return self._requeue(request);
         })
         .catch(error => {
-          debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): catch force requeue`);
+          debug(`_completeRequest(${loopName}:${request.toUniqueString()}): catch force requeue`);
           self.logger.error(error);
           throw error;
         })
@@ -247,7 +247,7 @@ class Crawler {
           return self._abandonInQueue(request);
         })
         .then(() => {
-          debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): exit (success - force requeue)`);
+          debug(`_completeRequest(${loopName}:${request.toUniqueString()}): exit (success - force requeue)`);
           return request;
         });
     }
@@ -259,39 +259,39 @@ class Crawler {
 
       const loggingPromise = originalPromise.then(result => {
         completedPromises++;
-        debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): completed ${completedPromises} of ${trackedPromises.length} promises (${failedPromises} failed)`);
+        debug(`_completeRequest(${loopName}:${request.toUniqueString()}): completed ${completedPromises} of ${trackedPromises.length} promises (${failedPromises} failed)`);
         return result;
       }, error => {
         completedPromises++;
         failedPromises++;
-        debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): completed ${completedPromises} of ${trackedPromises.length} promises (${failedPromises} failed)`);
+        debug(`_completeRequest(${loopName}:${request.toUniqueString()}): completed ${completedPromises} of ${trackedPromises.length} promises (${failedPromises} failed)`);
         throw error;
       });
     }
-    debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): ${trackedPromises.length} tracked promises`);
+    debug(`_completeRequest(${loopName}:${request.toUniqueString()}): ${trackedPromises.length} tracked promises`);
     const completeWork = Q.all(trackedPromises).then(
       () => {
-        debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): resolved tracked promises`);
+        debug(`_completeRequest(${loopName}:${request.toUniqueString()}): resolved tracked promises`);
         return self._releaseLock(request).then(
           () => {
             return self._deleteFromQueue(request);
           },
           error => {
-            debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): catch release lock`);
+            debug(`_completeRequest(${loopName}:${request.toUniqueString()}): catch release lock`);
             self.logger.error(error);
             return self._abandonInQueue(request);
           });
       },
       error => {
-        debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): catch tracked promises`);
+        debug(`_completeRequest(${loopName}:${request.toUniqueString()}): catch tracked promises`);
         self.logger.error(error);
         return self._completeRequest(request, true);
       });
     return completeWork.then(() => {
-      debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): exit (success)`);
+      debug(`_completeRequest(${loopName}:${request.toUniqueString()}): exit (success)`);
       return request;
     }).catch(error => {
-      debug(`_completeRequest(${request.meta.loopName}:${request.toUniqueString()}): catch completeWork`);
+      debug(`_completeRequest(${loopName}:${request.toUniqueString()}): catch completeWork`);
       throw error;
     });
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -42,6 +42,8 @@ class Request {
     this.start = Date.now();
     this.context = this.context || {};
     this._addHistory();
+    const root = this.context.history.length <= 1 ? 'self' : this.context.history[0];
+    this.addMeta({ root: root });
     this._resolvePolicy();
     return this;
   }
@@ -61,9 +63,9 @@ class Request {
     }
   }
 
-  _addHistory() {
+  _addHistory(request = null) {
     this.context.history = this.context.history || [];
-    this.context.history.push(this.toString());
+    this.context.history.push((request || this).toString());
   }
 
   hasSeen(request) {
@@ -246,12 +248,16 @@ class Request {
   }
 
   toString() {
-    return `${this.type}@${this.url}`;
+    return `${this.type}@${this._trimUrl(this.url)}`;
   }
 
   toUniqueString() {
     const policyName = this.policy ? Request._getResolvedPolicy(this).getShortForm() : 'NN';
     return `${this.type}@${this.url}:${policyName}`;
+  }
+
+  _trimUrl(url) {
+    return url ? url.replace('https://api.github.com', '') : '';
   }
 
   _log(level, message, meta = null) {


### PR DESCRIPTION
update the logging to add a root: property that shows the first request in the history (i.e., the cause of the request). 

This also required fixing up a few places where history was not being carried through.
