### PR TITLE
fix event type in etag issue

### DIFF
--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -458,7 +458,7 @@ class GitHubProcessor {
     const self = this;
     return Q.all(events.map(qlimit(10)(event => {
       const url = event.repo ? `${event.repo.url}/events/${event.id}` : `${event.org.url}/events/${event.id}`;
-      return self.store.etag('event', url).then(etag => {
+      return self.store.etag(event.type, url).then(etag => {
         return etag ? null : event;
       });
     }))).then(events => {


### PR DESCRIPTION
historically the redis mapping store did not use the "type" of a request when mapping entities.  The new table based store does.  Unfortunately, the event discovery code was generically using 'event' as the type for when looking up etags for events from the timeline.  This of course did not match anything so we never got any etags so we'd always queue all the events for a given repo on which something just happened.