### PR TITLE
uniquify the request event_trigger request url

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const appInsights = require('applicationinsights');
 const auth = require('./middleware/auth');
 const bodyParser = require('body-parser');
 const config = require('painless-config');
-const CrawlerService = require('./lib/crawlerService');
 const express = require('express');
 const logger = require('morgan');
 const mockInsights = require('./providers/logger/mockInsights');

--- a/lib/request.js
+++ b/lib/request.js
@@ -63,9 +63,9 @@ class Request {
     }
   }
 
-  _addHistory(request = null) {
+  _addHistory(message = null) {
     this.context.history = this.context.history || [];
-    this.context.history.push((request || this).toString());
+    this.context.history.push((message || this).toString());
   }
 
   hasSeen(request) {
@@ -174,6 +174,7 @@ class Request {
   }
 
   markRequeue(outcome, message) {
+    this._addHistory(` Requeued: ${outcome} ${message}`);
     return this._cutShort(outcome, message, 'requeue');
   }
 

--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -426,12 +426,15 @@ class GitHubProcessor {
   event_trigger(request) {
     request.markNoSave();
     if (this._isEventVisibleInTimeline(request.payload.type, request.payload.body.action)) {
-      const newRequest = new Request('update_events', request.url, request.context);
+      // If the request is visible in the timeline, toss the payload and queue an update_events request to query the timeline
+      const url = request.url.substr(0, request.url.lastIndexOf('/'));
+      const newRequest = new Request('update_events', url, request.context);
       request.queueRequests(newRequest, 'immediate');
     } else {
+      // Otherwise, this is as good as its going to get so queue the webhook event directly.
       const type = this._getTranslatedEventType(request.payload.type);
       const newContext = extend(true, {}, { history: request.context.history });
-      const newRequest = new Request(type, request.url + '/' + request.payload.guid, newContext);
+      const newRequest = new Request(type, request.url, newContext);
       newRequest.payload = request.payload;
       request.queueRequests(newRequest, 'immediate');
     }

--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -818,7 +818,7 @@ class GitHubProcessor {
       orgId = document.organization ? document.organization.id : null;
     }
     qualifier = qualifier || (repo ? `urn:repo:${repo}` : `urn:org:${orgId}`);
-    const id = document.id || request.payload.guid;
+    const id = document.id || request.payload.deliveryId;
     request.linkResource('self', `${qualifier}:${request.type}:${id}`);
     request.linkSiblings(`${qualifier}:${request.type}s`);
 

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -32,7 +32,7 @@ router.post('/', wrap(function* (request, response, next) {
   const event = JSON.parse(request.body);
   const eventsUrl = event.repository ? event.repository.events_url : event.organization.events_url;
   const result = new Request('event_trigger', `${eventsUrl}/${deliveryId}`);
-  result.payload = { body: event, etag: 1, fetchedAt: moment.utc().toISOString(), type: eventType, guid: deliveryId };
+  result.payload = { body: event, etag: 1, fetchedAt: moment.utc().toISOString(), type: eventType, deliveryId: deliveryId };
   // requests off directly off the event feed do not need exclusivity
   result.requiresLock = false;
   // if the event is for a private repo, mark the request as needing private access.


### PR DESCRIPTION
the event_trigger request is getting duplicated on the event queue because the event queue is not deduplicated.  Even if it were, we would have the reverse problem now that non-timeline events are supported.  In those situations, the payload is relevant so the request needs to be unique.  make the url unique by including the delivery id