### PR TITLE
make the requeue delay vary on attempt count

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -150,7 +150,7 @@ class Crawler {
         requestBox[0] = request.open(self);
         debug(`getRequestWork(${requestBox.loopName}:${request.toUniqueString()}): exit (success)`);
         if (request.attemptCount) {
-          return Q.delay(requestBox[0], self.options.requeueDelay || 30000);
+          return Q.delay(requestBox[0], (self.options.requeueDelay || 5000) * request.attemptCount);
         }
         return requestBox[0];
       })

--- a/lib/crawlerFactory.js
+++ b/lib/crawlerFactory.js
@@ -60,7 +60,7 @@ class CrawlerFactory {
         pollingDelay: 5000,
         processingTtl: 60 * 1000,
         promiseTrace: false,
-        requeueDelay: 30000,
+        requeueDelay: 5000,
         orgList: CrawlerFactory.loadOrgs()
       },
       fetcher: {


### PR DESCRIPTION
This is what i am thinking of for varying the attempt count.

There are 5 attempts in general.  for 404s we retry once with a stronger token.  In this model the collision case we are seeing will have 5,10,15, 20, 25 second delays.  So 75 seconds total.  We should (eventually) put in some telemetry to see how much retrying we are doing and how long we are waiting.