### PR TITLE
Add deadletterPolicy to exclude deadletters with 404 not found reason

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -524,6 +524,10 @@ class Crawler {
   storeDeadletter(request, reason = null) {
     const loopName = request.meta ? request.meta.loopName : '';
     debug(`_storeDeadletter(${loopName}:${request.toUniqueString()}): enter`);
+    if (this.options.deadletterPolicy === 'excludeNotFound' && reason && reason.toLowerCase().includes('status 404')) {
+      debug(`_storeDeadletter(${loopName}:${request.toUniqueString()}): not storing due to configured deadletter policy`);
+      return request;
+    }
     const document = this._createDeadletter(request, reason);
     return this.deadletters.upsert(document).then(() => {
       debug(`_storeDeadletter(${loopName}:${request.toUniqueString()}): exit (success)`);

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -523,14 +523,14 @@ class Crawler {
 
   storeDeadletter(request, reason = null) {
     const loopName = request.meta ? request.meta.loopName : '';
-    debug(`_storeDeadletter(${loopName}:${request.toUniqueString()}): enter`);
+    debug(`storeDeadletter(${loopName}:${request.toUniqueString()}): enter`);
     if (this.options.deadletterPolicy === 'excludeNotFound' && reason && reason.toLowerCase().includes('status 404')) {
-      debug(`_storeDeadletter(${loopName}:${request.toUniqueString()}): not storing due to configured deadletter policy`);
-      return request;
+      this.logger.info(`storeDeadletter(${loopName}:${request.toUniqueString()}): not storing due to configured deadletter policy`);
+      return Q(request);
     }
     const document = this._createDeadletter(request, reason);
     return this.deadletters.upsert(document).then(() => {
-      debug(`_storeDeadletter(${loopName}:${request.toUniqueString()}): exit (success)`);
+      debug(`storeDeadletter(${loopName}:${request.toUniqueString()}): exit (success)`);
       return request;
     });
   }

--- a/lib/crawlerFactory.js
+++ b/lib/crawlerFactory.js
@@ -61,7 +61,8 @@ class CrawlerFactory {
         processingTtl: 60 * 1000,
         promiseTrace: false,
         requeueDelay: 5000,
-        orgList: CrawlerFactory.loadOrgs()
+        orgList: CrawlerFactory.loadOrgs(),
+        deadletterPolicy: 'always' // Another option: excludeNotFound
       },
       fetcher: {
         tokenLowerBound: 50,


### PR DESCRIPTION
This change would allow to configure ghcrawler not to store deadletters with status 404 / not found reason.
@jeffmcaffer, could you please review?