### PR TITLE
Add sample configuration loaders for inMemory and ciab

### DIFF
--- a/configurations/ciab.js
+++ b/configurations/ciab.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const crawlerDefaults = {
+  name: config.get('CRAWLER_NAME') || 'crawler',
+  count: 1
+};
+
+const fetcherDefaults = {
+  githubTokens: options.githubTokens || config.get('CRAWLER_GITHUB_TOKENS'),
+  callCapStore: 'memory',
+  computeLimitStore: 'memory'
+};
+
+const queuingDefaults = {
+  weights: { events: 10, immediate: 3, soon: 2, normal: 3, later: 2 },
+};
+
+module.exports = function loadConfig() {
+  const services = {
+    logger: createLogger(),
+    configFactory: createRefreshingConfigFactory()
+  };
+
+  // Instantiate each of the required services and add them to the service list.
+  // Each service module has one or more factory functions that instantiates
+  // the service and addes it to the supplied list of services with the (optionally)
+  // given name.  The service may use or connect to other services supplied in the
+  // given service list. The factory function also returns the newly created service.
+  // Factory functions
+  require('redisLocker').create('locker', services);
+  require('mongoDocStore').create('store', services);
+  require('amqpQueues').create('queuing', services, queuingDefaults);
+  require('mongoDocStore').create('deadletters', services);
+  require('githubFetcher').create('fetcher', services, fetcherDefaults);
+  require('githubProcessor').create('processor', services);
+  require('crawler').create('crawler', services, crawlerDefaults);
+  return services;
+}
+

--- a/configurations/inmemory.js
+++ b/configurations/inmemory.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const crawlerDefaults = {
+  name: config.get('CRAWLER_NAME') || 'crawler',
+  count: 1
+};
+
+const fetcherDefaults = {
+  githubTokens: options.githubTokens || config.get('CRAWLER_GITHUB_TOKENS'),
+  callCapStore: 'memory',
+  computeLimitStore: 'memory'
+};
+
+const queuingDefaults = {
+  weights: { events: 10, immediate: 3, soon: 2, normal: 3, later: 2 },
+};
+
+module.exports = function loadConfig() {
+  const services = {
+    logger: createLogger(),
+    configFactory: createInMemoryOptionsFactory()
+  };
+
+  // Instantiate each of the required services and add them to the service list.
+  // Each service module has one or more factory functions that instantiates
+  // the service and addes it to the supplied list of services with the (optionally)
+  // given name.  The service may use or connect to other services supplied in the
+  // given service list. The factory function also returns the newly created service.
+  // Factory functions
+  require('nullLocker').create('locker', services);
+  require('inMemoryStore').create('store', services);
+  require('inMemoryQueues').create('queuing', services, queuingDefaults);
+  require('inMemoryStore').create('deadletters', services);
+  require('githubFetcher').create('fetcher', services, fetcherDefaults);
+  require('githubProcessor').create('processor', services);
+  require('crawler').create('crawler', services, crawlerDefaults);
+  return services;
+}
+


### PR DESCRIPTION
Sketched out implementations of two different config loaders that go with the PR from @patrick-steele-idem for refactoring the crawler factory.  That PR should end up in this branch eventually.

This change takes a poor man's dependency injection approach (thanks @willbar).  The basic idea is that a _config loader_ creates effectively a dependency injection container full of _services_ that make up the crawler (including the crawler itself).  Each service is created by a factory (or whatever you want).  The standard pattern is for the factory function to get a container of services previously created, an optional name (if provided it should add itself to the container) and an optional set of default settings.

There is also a philosophical change in that the provider code should have core defaults built in so the user does not have to spec any/many options.  We'll have to document the available options for each provider but that's a good thing anyway.  