### PR TITLE
Fix the config/tokens endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ app.use(sendHelper());
 // Note also that the GitHub doc says events are capped at 5mb
 app.use('/webhook', bodyParser.raw({ limit: '5mb', type: '*/*' }), require('./routes/webhook')(service, config.get('CRAWLER_WEBHOOK_SECRET')));
 // It's safe to set limitation to 2mb.
-app.use(bodyParser.json({ limit: '2mb' }));
+app.use(bodyParser.json({ limit: '2mb' , strict: false}));
 app.use('/status', require('./routes/status')(service));
 app.use('/config', require('./routes/config')(service));
 app.use('/requests', require('./routes/requests')(service));

--- a/providers/fetcher/limitedTokenFactory.js
+++ b/providers/fetcher/limitedTokenFactory.js
@@ -53,6 +53,10 @@ class LimitedTokenFactory {
   setTokens(tokens) {
     this.factory.setTokens(tokens);
   }
+
+  getAllTokens() {
+    return this.factory.getAllTokens();
+  }
 }
 
 module.exports = LimitedTokenFactory;

--- a/providers/fetcher/tokenFactory.js
+++ b/providers/fetcher/tokenFactory.js
@@ -28,6 +28,10 @@ class TokenFactory {
     this.tokens = tokenSpecs.map(spec => TokenFactory.createToken(spec));
   }
 
+  getAllTokens() {
+    return this.tokens;
+  }
+
   /**
    * Given a collection of trait sets, find the first set that has any number of matching tokens in the
    * factory.  From that set return a random one that is not on the bench. If all candidates are benched,

--- a/routes/config.js
+++ b/routes/config.js
@@ -34,7 +34,9 @@ router.put('/tokens', auth.validate, (request, response, next) => {
 });
 
 router.get('/tokens', auth.validate, (request, response, next) => {
-  response.json(crawlerService.crawler.fetcher.tokenFactory.getAllTokens()).status(200).end();
+  let tokens = crawlerService.crawler.fetcher.tokenFactory.getAllTokens();
+  let shortTokens = tokens.map(t => {return {value: t.value.substr(0,8) + "...", traits: t.traits}});
+  response.json(shortTokens).status(200).end();
 });
 
 function setup(service) {

--- a/routes/config.js
+++ b/routes/config.js
@@ -27,10 +27,14 @@ router.get('/', auth.validate, function (request, response, next) {
   response.json(result).status(200).end();
 });
 
-router.post('/tokens', auth.validate, (request, response, next) => {
+router.put('/tokens', auth.validate, (request, response, next) => {
   const body = request.body;
-  crawlerService.fetcher.tokenFactory.setTokens(body);
+  crawlerService.crawler.fetcher.tokenFactory.setTokens(body);
   response.sendStatus(200);
+});
+
+router.get('/tokens', auth.validate, (request, response, next) => {
+  response.json(crawlerService.crawler.fetcher.tokenFactory.getAllTokens()).status(200).end();
 });
 
 function setup(service) {


### PR DESCRIPTION
Fix the config/tokens endpoint, which does not work from bin/cc as it currently stands.

bin/cc sends a list of tokens as a simple JSON string, colon-separated, by PUT. This gets rejected by strict body-parser JSON parsing (which expects JSON to be an array or an object), and also by config.js which expects config/tokens to be addressed as POST.
Add a GET verb to the /config/tokens endpoint to list the tokens that have already been added.

(Fixes https://github.com/Microsoft/ghcrawler-cli/issues/8)