### PR TITLE
Persist messages when sending to AMQP queue

### DIFF
--- a/providers/queuing/amqpQueue.js
+++ b/providers/queuing/amqpQueue.js
@@ -69,7 +69,7 @@ class AmqpQueue {
       const body = JSON.stringify(request);
       const deferred = Q.defer();
       this.channel.then(channel => {
-        channel.sendToQueue(this.queueName, new Buffer(body), {}, (err, ok) => {
+        channel.sendToQueue(this.queueName, new Buffer(body), { persistent: true }, (err, ok) => {
           if (err) {
             return deferred.reject(err);
           }


### PR DESCRIPTION
We need to specify:
{ persistent: true }

When we publish messages for the server to actual persist them http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish.