### PR TITLE
add filter pluggability and options "dispatcher" notion

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -376,23 +376,21 @@ class Crawler {
       return request;
     }
     return this._logStartEnd('fetching', request, () => {
-      const handler = this._getFetcher(request);
+      const handler = this._getHandler(request, this.fetchers);
       if (!handler) {
         request.markDead('Error', `No fetcher found for request type: ${request.type}`);
         return request;
       }
-      return handler(request);
+      return handler.handle(request);
     }).then(request => {
       debug(`_fetch(${loopName}:${request.toUniqueString()}): exit (success - fetched)`);
       return request;
     });
   }
 
-  _getFetcher(request) {
-    for (let i = 0; i < this.fetchers.length; i++) {
-      const fetcher = this.fetchers[i];
-      const handler = fetcher.getHandler(request);
-      if (handler)
+  _getHandler(request, list) {
+    for (let handler of list) {
+      if (handler.canHandle(request))
         return handler;
     }
     return null;
@@ -442,6 +440,7 @@ class Crawler {
     // If the doc is an array,
     // * wrap it in an object to make storage more consistent (Mongo can't store arrays directly)
     // * save the link header as GitHub will not return those in a subsequent 304
+    request.document = request.document || {};
     if (Array.isArray(request.document)) {
       request.document = { elements: request.document };
     }
@@ -474,20 +473,20 @@ class Crawler {
   }
 
   _process(request) {
-    const handler = this._getHandler(request);
+    const handler = this._getHandler(request, this.processors);
     if (!handler) {
       request.markDead('Error', `No handler found for request type: ${request.type}`);
       return Q(request);
     }
 
     const oldVersion = request.document._metadata.version;
-    if (request.policy.shouldProcess(request, this.version)) {
+    if (handler.shouldProcess(request)) {
       request.processMode = 'process';
     } else {
       // We are not going to process but may still need to traverse the doc to get to referenced docs that
       // do need processing. If so, mark the request for no saving (already have good content) and carry on.
       // Otherwise, skip the doc altogether.
-      if (request.policy.shouldTraverse(request)) {
+      if (handler.shouldTraverse(request)) {
         request.processMode = 'traverse';
         request.markNoSave();
       } else {
@@ -496,13 +495,13 @@ class Crawler {
       }
     }
 
-    return Q(handler(request)).then(result => {
+    return Q(handler.handle(request)).then(result => {
       if (result) {
         // Be resilient to processors returning either the request or a document.
         request.document = result === request ? request.document : result;
         const metadata = request.document._metadata;
         metadata.processedAt = moment.utc().toISOString();
-        if (metadata.version !== oldVersion) {
+        if (request.save !== false && metadata.version !== oldVersion) {
           request.markSave();
         }
       }
@@ -511,17 +510,6 @@ class Crawler {
       }
       return request;
     });
-  }
-
-
-  _getHandler(request) {
-    for (let i = 0; i < this.processors.length; i++) {
-      const processor = this.processors[i];
-      const handler = processor.getHandler(request);
-      if (handler)
-        return handler;
-    }
-    return null;
   }
 
   _logStartEnd(name, request, work) {

--- a/lib/traversalPolicy.js
+++ b/lib/traversalPolicy.js
@@ -179,10 +179,17 @@ class TraversalPolicy {
       // TODO this is not quite right. To tell time freshness we need to get the cached version but if we need to process
       // we need the content from origin. Essentially we need to read the processed time with the etag (at that point)
       // determine if the content is stale.  Testing here is too late.
-      return moment.diff(request.document._metadata.processedAt, 'hours') > this.freshness * 24;
+      return
+        !request.document
+        || !request.document._metadata
+        || !request.document._metadata.processedAt
+        || moment.diff(request.document._metadata.processedAt, 'hours') > this.freshness * 24;
     }
     if (this.freshness === 'version' || this.freshness === 'matchOrVersion') {
-      return !request.document._metadata.version || (request.document._metadata.version < version);
+      return !request.document
+        || !request.document._metadata
+        || !request.document._metadata.version
+        || (request.document._metadata.version < version);
     }
     throw new Error('Invalid freshness in traversal policy');
   }

--- a/providers/storage/storageDocStore.js
+++ b/providers/storage/storageDocStore.js
@@ -207,7 +207,7 @@ class AzureStorageDocStore {
   }
 
   _getBlobNameFromUrl(type, url) {
-    if (!(url.startsWith('http:') || url.startsWith('https:'))) {
+    if (url.startsWith('urn:')) {
       return url;
     }
     const parsed = URL.parse(url, true);


### PR DESCRIPTION
To enable more general fetching, filtering and caching by crawlers, this PR does:

* Add `filter` as a pluggable and configurable element. Filters asnwer questions like `shouldFetch`, `shouldProcess`...  Factoring this out allows crawlers to control their behavior more independently
* Add the notion of a `dispatcher` to a configuration domain. For example, previously there was either one fetcher provider or a list that were equally weighted. This made it hard for a crawler to define their own fetch caching strategy. The new approach allows crawlers to define one provider as the `dispatcher` that is responsible for handling all requests but which has all the other related handlers (e.g., fetchers) available to it.

Most of the changes here are plumbing to make this happen.