### PR TITLE
Gh/storage queue

### DIFF
--- a/providers/index.js
+++ b/providers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation and others. Made available under the MIT license.
 // SPDX-License-Identifier: MIT
 
 module.exports = {
@@ -6,6 +6,7 @@ module.exports = {
     amqp: require('./queuing/amqpFactory'),
     amqp10: require('./queuing/amqp10Factory'),
     serviceBus: require('./queuing/serviceBusFactory'),
+    storageQueueFactory: require('./queuing/storageQueueFactory'),
     memory: require('./queuing/memoryFactory'),
     amqp10Subscription: require('./queuing/amqp10SubscriptionFactory'),
     webhook: require('./queuing/webhookFactory')

--- a/providers/index.js
+++ b/providers/index.js
@@ -6,7 +6,7 @@ module.exports = {
     amqp: require('./queuing/amqpFactory'),
     amqp10: require('./queuing/amqp10Factory'),
     serviceBus: require('./queuing/serviceBusFactory'),
-    storageQueueFactory: require('./queuing/storageQueueFactory'),
+    storageQueue: require('./queuing/storageQueueFactory'),
     memory: require('./queuing/memoryFactory'),
     amqp10Subscription: require('./queuing/amqp10SubscriptionFactory'),
     webhook: require('./queuing/webhookFactory')

--- a/providers/queuing/amqp10Factory.js
+++ b/providers/queuing/amqp10Factory.js
@@ -11,7 +11,7 @@ const CrawlerFactory = require('../../crawlerFactory');
 
 module.exports = options => {
   const { managementEndpoint, url } = options;
-  const manager = new ServiceBusQueueManager(url, managementEndpoint, false, options);
+  const manager = new ServiceBusQueueManager(url, managementEndpoint, false);
   const env = process.env.NODE_ENV;
   let tracker;
   if (options.tracker) {

--- a/providers/queuing/serviceBusFactory.js
+++ b/providers/queuing/serviceBusFactory.js
@@ -10,7 +10,7 @@ const CrawlerFactory = require('../../crawlerFactory');
 
 module.exports = options => {
   const { connectionString } = options;
-  const manager = new ServiceBusQueueManager(null, connectionString, true, options);
+  const manager = new ServiceBusQueueManager(null, connectionString, true);
   const env = process.env.NODE_ENV;
   let tracker;
   if (options.tracker) {

--- a/providers/queuing/serviceBusQueueManager.js
+++ b/providers/queuing/serviceBusQueueManager.js
@@ -18,7 +18,7 @@ const AmqpClient = amqp10.Client;
 const AmqpPolicy = amqp10.Policy;
 
 class ServiceBusQueueManager {
-  constructor(amqpUrl, managementEndpoint, isServiceBusQueue = false, options) {
+  constructor(amqpUrl, managementEndpoint, isServiceBusQueue = false) {
     this.amqpUrl = amqpUrl;
     this.managementEndpoint = managementEndpoint;
     this.isServiceBusQueue = isServiceBusQueue;

--- a/providers/queuing/storageQueue.js
+++ b/providers/queuing/storageQueue.js
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation and others. Made available under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const Q = require('q');
+const qlimit = require('qlimit');
+
+class StorageQueue {
+  constructor(client, name, queueName, formatter, options) {
+    this.client = client;
+    this.name = name;
+    this.queueName = queueName;
+    this.messageFormatter = formatter;
+    this.options = options;
+    this.logger = options.logger;
+  }
+
+  subscribe() {
+    const deferred = Q.defer();
+    this.client.createQueueIfNotExists(this.queueName, (error) => {
+      if (error) {
+        return deferred.reject(error);
+      }
+      this.logger.info(`Subscribed to ${this.queueName} using Queue Storage`);
+      deferred.resolve();
+    });
+    return deferred.promise;
+  }
+
+  unsubscribe() {
+    return Q();
+  }
+
+  push(requests) {
+    requests = Array.isArray(requests) ? requests : [requests];
+    return Q.all(requests.map(qlimit(this.options.parallelPush || 1)(request => {
+      const body = JSON.stringify(request);
+      const deferred = Q.defer();
+      this.client.createMessage(this.queueName, body, (error) => {
+        if (error) {
+          return deferred.reject(error);
+        }
+        this._incrementMetric('push');
+        this._log('Queued', request);
+        deferred.resolve();
+      });
+      return deferred.promise;
+    })));
+  }
+
+  pop() {
+    const msgOptions = { numOfMessages: 1, visibilityTimeout: this.options.visibilityTimeout || 60 * 60 };
+    const deferred = Q.defer();
+    this.client.getMessages(this.queueName, msgOptions, (error, result) => {
+      if (error) {
+        return deferred.reject(error);
+      }
+      this._incrementMetric('pop');
+      const message = result[0];
+      if (!message) {
+        this.logger.verbose('No messages to receive');
+        return deferred.resolve(null);
+      }
+      message.body = JSON.parse(message.messageText);
+      const request = this.messageFormatter(message);
+      request._message = message;
+      this._log('Popped', message.body);
+      deferred.resolve(request);
+    });
+    return deferred.promise;
+  }
+
+  done(request) {
+    if (!request || !request._message) {
+      return Q();
+    }
+    const deferred = Q.defer();
+    this.client.deleteMessage(this.queueName, request._message.messageId, request._message.popReceipt, (error) => {
+      if (error) {
+        return deferred.reject(error);
+      }
+      this._incrementMetric('done');
+      this._log('ACKed', request._message.body);
+      deferred.resolve();
+    });
+    return deferred.promise;
+  }
+
+  defer(request) {
+    this._incrementMetric('defer');
+    return this.abandon(request);
+  }
+
+  abandon(request) {
+    if (!request || !request._message) {
+      return Q();
+    }
+    const deferred = Q.defer();
+    // visibilityTimeout is updated to 0 to unlock/unlease the message
+    this.client.updateMessage(this.queueName, request._message.messageId, request._message.popReceipt, 0, (error) => {
+      if (error) {
+        return deferred.reject(error);
+      }
+      this._incrementMetric('abandon');
+      this._log('NAKed', request._message.body);
+      deferred.resolve();
+    });
+    return deferred.promise;
+  }
+
+  flush() {
+    const deleteQueue = Q.nbind(this.client.deleteQueue, this.client);
+    const createQueueIfNotExists = Q.nbind(this.client.createQueueIfNotExists, this.client);
+    return deleteQueue(this.queueName).then(createQueueIfNotExists(this.queueName));
+  }
+
+  getInfo() {
+    const getQueueMetadata = Q.nbind(this.client.getQueueMetadata, this.client);
+    return getQueueMetadata(this.queueName).then(result => {
+      return Q({ count: result[0].approximateMessageCount });
+    }).catch(error => {
+      this.logger.error(error);
+      return Q(null);
+    });
+  }
+
+  getName() {
+    return this.name;
+  }
+
+  _incrementMetric(operation) {
+    const metrics = this.logger.metrics;
+    if (metrics && metrics[this.name] && metrics[this.name][operation]) {
+      metrics[this.name][operation].incr();
+    }
+  }
+
+  _log(actionMessage, message) {
+    this.logger.verbose(`${actionMessage} ${message.type} ${message.url}`);
+  }
+}
+
+module.exports = StorageQueue;

--- a/providers/queuing/storageQueueFactory.js
+++ b/providers/queuing/storageQueueFactory.js
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation and others. Made available under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const StorageQueueManager = require('./storageQueueManager');
+const CrawlerFactory = require('../../crawlerFactory');
+
+module.exports = options => {
+  const { connectionString } = options;
+  const manager = new StorageQueueManager(connectionString, options);
+  const env = process.env.NODE_ENV;
+  let tracker;
+  if (options.tracker) {
+    tracker = CrawlerFactory.createRequestTracker(`${env}:ServiceBus:${options.queueName}`, options);
+  }
+  return CrawlerFactory.createQueueSet(manager, tracker, options);
+}

--- a/providers/queuing/storageQueueManager.js
+++ b/providers/queuing/storageQueueManager.js
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation and others. Made available under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const AttenuatedQueue = require('./attenuatedQueue');
+const AzureStorage = require('azure-storage');
+const Request = require('../../lib/request');
+const StorageQueue = require('./storageQueue');
+const TrackedQueue = require('./trackedQueue');
+
+class StorageQueueManager {
+  constructor(connectionString) {
+    const retryOperations = new AzureStorage.ExponentialRetryPolicyFilter();
+    this.client = AzureStorage.createQueueService(connectionString).withFilter(retryOperations);
+  }
+
+  createQueueClient(name, formatter, options) {
+    return new StorageQueue(this.client, name, `${options.queueName}-${name}`, formatter, options);
+  }
+
+  createQueueChain(name, tracker, options) {
+    const formatter = message => {
+      // make sure the message/request object is copied to enable deferral scenarios (i.e., the request is modified
+      // and then put back on the queue)
+      return Request.adopt(Object.assign({}, message.body));
+    };
+    let queue = this.createQueueClient(name, formatter, options);
+    if (tracker) {
+      queue = new TrackedQueue(queue, tracker, options);
+    }
+    return new AttenuatedQueue(queue, options);
+  }
+}
+
+module.exports = StorageQueueManager;

--- a/test/integration/serviceBusQueueTests.js
+++ b/test/integration/serviceBusQueueTests.js
@@ -33,19 +33,19 @@ const options = {
 };
 let serviceBusQueue = null;
 
-describe('AMQP 1.0 Integration', () => {
+describe('Service Bus Integration', () => {
   before(async () => {
     if (!connectionString) {
       throw new Error('ServiceBus connectionString not configured.');
     }
-    const manager = new ServiceBusQueueManager(null, connectionString, true, options);
+    const manager = new ServiceBusQueueManager(null, connectionString, true);
     serviceBusQueue = new ServiceBusQueue(manager.serviceBusService, name, queueName, formatter, manager, options);
     await serviceBusQueue.subscribe();
   });
 
-  // after(async () => {
-  //   await serviceBusQueue.flush();
-  // });
+  after(async () => {
+    await serviceBusQueue.flush();
+  });
 
   it('Should push, pop and ack a message', async () => {
     let info = await serviceBusQueue.getInfo();

--- a/test/integration/storageQueueTests.js
+++ b/test/integration/storageQueueTests.js
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation and others. Made available under the MIT license.
+// SPDX-License-Identifier: MIT
+
+// Run ./node_modules/mocha/bin/mocha test/integration/storageQueueTests.js --timeout 40000
+const config = require('painless-config');
+const { expect } = require('chai');
+const { after, before, describe, it } = require('mocha');
+const { promisify } = require('util');
+const Request = require('../../lib/request');
+const StorageQueue = require('../../providers/queuing/storageQueue');
+const StorageQueueManager = require('../../providers/queuing/storageQueueManager');
+
+const connectionString = config.get('AZQUEUE_CONNECTION_STRING');
+const name = config.get('CRAWLER_NAME');
+const queueName = 'storage-queue-test';
+const formatter = message => {
+  Request.adopt(message);
+  return message;
+};
+const options = {
+  logger: {
+    info: console.log,
+    verbose: console.log,
+    error: console.error
+  },
+  queueName,
+  visibilityTimeout: 3 // in sec
+};
+let storageQueue = null;
+
+describe('Azure Storage Queue Integration', () => {
+  before(async () => {
+    if (!connectionString) {
+      throw new Error('Storage Queue connectionString not configured.');
+    }
+    const manager = new StorageQueueManager(connectionString);
+    storageQueue = new StorageQueue(manager.client, name, queueName, formatter, options);
+    await storageQueue.subscribe();
+  });
+
+  // after(async () => {
+  //   await storageQueue.flush();
+  // });
+
+  it('Should push, pop and ack a message, pop empty queue', async () => {
+    let info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(0);
+    const msg = new Request('test1', 'test://test/test1');
+    await storageQueue.push(msg);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    let request = await storageQueue.pop();
+    expect(request).to.exist;
+    expect(request instanceof Request).to.be.true;
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    await storageQueue.done(request);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(0);
+
+    request = await storageQueue.pop();
+    expect(request).to.be.null;
+  });
+
+  it('Should push, pop, nack, pop and ack a message', async () => {
+    let info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(0);
+    const msg = new Request('test2', 'test://test/test2');
+    await storageQueue.push(msg);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    let request = await storageQueue.pop();
+    expect(request).to.exist;
+    expect(request instanceof Request).to.be.true;
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    await storageQueue.abandon(request);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    request = await storageQueue.pop();
+    expect(request).to.exist;
+    expect(request instanceof Request).to.be.true;
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    await storageQueue.done(request);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(0);
+  });
+
+  it('Should push, pop, wait for message to be unlocked, pop and ack a message', async () => {
+    let info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(0);
+    const msg = new Request('test3', 'test://test/test3');
+    await storageQueue.push(msg);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    let request = await storageQueue.pop();
+    expect(request).to.exist;
+    expect(request instanceof Request).to.be.true;
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    await setTimeout[promisify.custom](4000);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    request = await storageQueue.pop();
+    expect(request).to.exist;
+    expect(request instanceof Request).to.be.true;
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(1);
+
+    await storageQueue.done(request);
+    info = await storageQueue.getInfo();
+    expect(Number(info.count)).to.equal(0);
+  });
+});
+
+function getTimerAsyncId(timeoutId) {
+  return timeoutId[Object.getOwnPropertySymbols(timeoutId)[0]];
+}

--- a/test/integration/storageQueueTests.js
+++ b/test/integration/storageQueueTests.js
@@ -122,7 +122,3 @@ describe('Azure Storage Queue Integration', () => {
     expect(Number(info.count)).to.equal(0);
   });
 });
-
-function getTimerAsyncId(timeoutId) {
-  return timeoutId[Object.getOwnPropertySymbols(timeoutId)[0]];
-}

--- a/test/integration/storageQueueTests.js
+++ b/test/integration/storageQueueTests.js
@@ -38,9 +38,9 @@ describe('Azure Storage Queue Integration', () => {
     await storageQueue.subscribe();
   });
 
-  // after(async () => {
-  //   await storageQueue.flush();
-  // });
+  after(async () => {
+    await storageQueue.flush();
+  });
 
   it('Should push, pop and ack a message, pop empty queue', async () => {
     let info = await storageQueue.getInfo();


### PR DESCRIPTION
**Implement Azure storage queue provider.**
Azure storage queue is more suitable for our use cases than the Service Bus because of the following:

- Messages can be leased for up to a week compared to maximum 5 min in Azure Service Bus, thus eliminating a need for timers. 
- It is faster and cheaper.
- Azure Storage Explorer as well as the portal make it much easier to inspect queues' contents.
- More reliable (no partitioning related bugs etc).