### PR TITLE
docker-compose: include persistent volumes for redis, rabbitmq, mongo…

### DIFF
--- a/docker/common-services.yml
+++ b/docker/common-services.yml
@@ -6,11 +6,15 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
   rabbitmq:
     image: rabbitmq:management
     ports:
       - "5672:5672"
       - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
   dashboard:
     build: ../../ghcrawler-dashboard
     ports:
@@ -29,6 +33,9 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
+    volumes:
+      - mongo_data_db:/data/db
+      - mongo_configdb:/data/configdb
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
     ports:
@@ -43,6 +50,8 @@ services:
     image: metabase/metabase:latest
     ports:
       - "5000:3000"
+    volumes:
+      - metabase_data:/var/opt/metabase
     # links:
     #   - mongo
   crawler:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,3 +38,9 @@ services:
       - mongo
       - redis
       - rabbitmq
+volumes:
+  redis_data:
+  rabbitmq_data:
+  mongo_configdb:
+  mongo_data_db:
+  metabase_data:

--- a/docker/elastic.yml
+++ b/docker/elastic.yml
@@ -40,3 +40,6 @@ services:
       - elasticsearch
       - redis
       - rabbitmq
+volumes:
+  redis_data:
+  rabbitmq_data:

--- a/docker/mongo.yml
+++ b/docker/mongo.yml
@@ -35,3 +35,9 @@ services:
       - mongo
       - redis
       - rabbitmq
+volumes:
+  redis_data:
+  rabbitmq_data:
+  mongo_configdb:
+  mongo_data_db:
+  metabase_data:


### PR DESCRIPTION
…db, metabase

Notes:
* wasn't possible in compose 2.0 versions to include the volumes into other files like the services; and
* I've kept to the 2.0 version as the ```extend``` syntax is removed in 3.0. Reintroduction is being considered. compose-3.0 has a different volume syntax too when migration to 3.0 happens. 

closes #134 