### PR TITLE
Docker ports - use expose and limit 'ports' to 127.0.0.1

### DIFF
--- a/docker/common-services.yml
+++ b/docker/common-services.yml
@@ -4,21 +4,22 @@ version: "2.0"
 services:
   redis:
     image: redis:latest
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"
     volumes:
       - redis_data:/data
   rabbitmq:
     image: rabbitmq:management
+    expose:
+      - "5672"
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "127.0.0.1:15672:15672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
   dashboard:
     build: ../../ghcrawler-dashboard
     ports:
-      - "4000:4000"
+      - "127.0.0.1:4000:4000"
     environment:
       - NODE_ENV=localhost
       - DEBUG_ALLOW_HTTP=1
@@ -31,25 +32,24 @@ services:
   mongo:
     image: mongo:latest
     ports:
-      - "27017:27017"
-      - "28017:28017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongo_data_db:/data/db
       - mongo_configdb:/data/configdb
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
-    ports:
-      - "9200:9200"
+    expose:
+      - "9200"
   kibana:
     image: docker.elastic.co/kibana/kibana:5.4.0
     ports:
-      - "5601:5601"
+      - "127.0.0.1:5601:5601"
     # links:
     #   - elasticsearch
   metabase:
     image: metabase/metabase:latest
     ports:
-      - "5000:3000"
+      - "127.0.0.1:5000:3000"
     volumes:
       - metabase_data:/var/opt/metabase
     # links:

--- a/docker/common-services.yml
+++ b/docker/common-services.yml
@@ -6,11 +6,15 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
   rabbitmq:
     image: rabbitmq:management
     ports:
       - "5672:5672"
       - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
   dashboard:
     build: ../../ghcrawler-dashboard
     ports:
@@ -29,6 +33,9 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
+    volumes:
+      - mongo_data_db:/data/db
+      - mongo_configdb:/data/configdb
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
     ports:
@@ -43,6 +50,8 @@ services:
     image: metabase/metabase:latest
     ports:
       - "5000:3000"
+    volumes:
+      - metabase_data:/var/opt/metabase
     # links:
     #   - mongo
   crawler:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,3 +38,9 @@ services:
       - mongo
       - redis
       - rabbitmq
+volumes:
+  redis_data:
+  rabbitmq_data:
+  mongo_configdb:
+  mongo_data_db:
+  metabase_data:

--- a/docker/elastic.yml
+++ b/docker/elastic.yml
@@ -40,3 +40,6 @@ services:
       - elasticsearch
       - redis
       - rabbitmq
+volumes:
+  redis_data:
+  rabbitmq_data:

--- a/docker/mongo.yml
+++ b/docker/mongo.yml
@@ -35,3 +35,9 @@ services:
       - mongo
       - redis
       - rabbitmq
+volumes:
+  redis_data:
+  rabbitmq_data:
+  mongo_configdb:
+  mongo_data_db:
+  metabase_data:


### PR DESCRIPTION
this is on top of the volumes commit as there's a lot of fuzz otherwise.

Basicly using expose as a directive to share ports in the same docker-compose grou.

127.0.0.1 for other service. I included mongo db here as the data is being gathered for another service (Measure).
