### PR TITLE
Do not add issue & issue comments to pull request entity

### DIFF
--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -300,13 +300,6 @@ class GitHubProcessor {
     if (document._links.commits && document.commits) {
       this._addCollection(request, 'pull_request_commits', 'pull_request_commit', document._links.commits.href);
     }
-
-    // link and queue the related issue.  Getting the issue will bring in the comments for this PR
-    if (document._links.issue) {
-      // link to the relate issue and its comments.
-      request.linkResource('issue', `${context.qualifier}:issue:${document.id}`);
-      request.linkCollection('issue_comments', `${context.qualifier}:issue:${document.id}:issue_comments`);
-    }
     return document;
   }
 


### PR DESCRIPTION
Even though pull requests are a subset of issues and their numbers may be the same, the IDs of issues and pull requests are always different. 
Since pulls API doesn't contain its corresponding issue ID, issue resource and issue_comments collection should be removed from pull request entities.
https://developer.github.com/v3/pulls/#get-a-single-pull-request