### PR TITLE
Resolve TypeError: Cannot read property 'id' of null for PullRequestR…

### DIFF
--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -706,6 +706,7 @@ class GitHubProcessor {
       return null;
     }
     let [document, repo, payload] = this._addEventBasics(request);
+    // Sometimes payload.pull_request is null instead of an object.
     if (!payload.pull_request) {
       return document;
     }

--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -705,7 +705,10 @@ class GitHubProcessor {
       request.queue('LegacyPullRequestReviewCommentEvent', request.document.payload.comment.pull_request_url, request.policy, context);
       return null;
     }
-    let [, repo, payload] = this._addEventBasics(request);
+    let [document, repo, payload] = this._addEventBasics(request);
+    if (!payload.pull_request) {
+      return document;
+    }
     const qualifier = `urn:repo:${repo}:pull_request:${payload.pull_request.id}`;
     if (payload.action === 'deleted') {
       const context = { deletedAt: request.payload.fetchedAt };


### PR DESCRIPTION
Resolve _TypeError: Cannot read property 'id' of null_ error for PullRequestReviewCommentEvent in a rare case when payload.pull_request is null.