### PR TITLE
Crawl user events - resolves #146

### DIFF
--- a/lib/visitorMap.js
+++ b/lib/visitorMap.js
@@ -248,7 +248,8 @@ const repo = {
 
 const user = {
   _type: 'user',
-  repos: collection(repo)
+  repos: collection(repo),
+  events: collection(event)
 };
 
 const org = {

--- a/providers/fetcher/githubFetcher.js
+++ b/providers/fetcher/githubFetcher.js
@@ -272,7 +272,7 @@ class GitHubFetcher {
       teams: { tokenTraits: ['admin'] },
       team: { tokenTraits: ['admin'] },
       members: { tokenTraits: ['admin'] },
-      events: { tokenTraits: ['admin'] },
+      events: { tokenTraits: [['admin'], ['public']] },
       collaborators: { tokenTraits: ['admin'], headers: { Accept: 'application/vnd.github.korra-preview' } },
       reviews: { headers: { Accept: 'application/vnd.github.black-cat-preview+json' } },
       review: { headers: { Accept: 'application/vnd.github.black-cat-preview+json' } },

--- a/providers/fetcher/githubProcessor.js
+++ b/providers/fetcher/githubProcessor.js
@@ -151,6 +151,7 @@ class GitHubProcessor {
     request.linkSiblings('urn:users');
 
     this._addCollection(request, 'repos', 'repo');
+    this._addCollection(request, 'events', null, document.events_url.replace('{/privacy}', ''));
     return document;
   }
 

--- a/routes/requests.js
+++ b/routes/requests.js
@@ -66,8 +66,13 @@ function buildRequestFromSpec(spec) {
   let crawlType = null;
   let crawlUrl = 'https://api.github.com/';
   if (spec.indexOf('/') > -1) {
-    crawlType = 'repo';
-    crawlUrl += 'repos/' + spec;
+    if(spec.slice(0, 6)==="users/") {
+      crawlType = 'user';
+      crawlUrl += spec;
+    } else {
+      crawlType = 'repo';
+      crawlUrl += 'repos/' + spec;
+    }
   } else {
     crawlType = 'org';
     crawlUrl += 'orgs/' + spec;

--- a/test/unit/crawlerTests.js
+++ b/test/unit/crawlerTests.js
@@ -759,7 +759,7 @@ describe('Crawler whole meal deal', () => {
     const request = new Request('user', 'http://test.com/users/user1');
     request.policy = TraversalPolicy.reload('user');
     normal.requests = [request];
-    crawler.fetcher.responses = [createResponse({ id: 42, repos_url: 'http://test.com/users/user1/repos' })];
+    crawler.fetcher.responses = [createResponse({ id: 42, repos_url: 'http://test.com/users/user1/repos', events_url: 'http://test.com/users/user1/events' })];
     return Q.try(() => { return crawler.processOne({ name: 'test' }); }).then(
       () => {
         expect(normal.pop.callCount).to.be.equal(1);

--- a/test/unit/gitHubProcessorTests.js
+++ b/test/unit/gitHubProcessorTests.js
@@ -179,6 +179,7 @@ describe('User processing', () => {
       _metadata: { links: {} },
       id: 9,
       repos_url: 'http://repos',
+      events_url: 'https://api.github.com/users/testuser/events',
     };
 
     const processor = new GitHubProcessor();
@@ -187,12 +188,14 @@ describe('User processing', () => {
     const links = {
       self: { href: 'urn:user:9', type: 'resource' },
       siblings: { href: 'urn:users', type: 'collection' },
-      repos: { href: 'urn:user:9:repos', type: 'collection' }
+      repos: { href: 'urn:user:9:repos', type: 'collection' },
+      events: {href: 'urn:user:9:events', type: 'collection'}
     }
     expectLinks(document._metadata.links, links);
 
     const expected = [
       { type: 'repos', url: 'http://repos', qualifier: 'urn:user:9', path: '/repos' },
+      { type: 'events', url: 'https://api.github.com/users/testuser/events', qualifier: 'urn:user:9', path: '/events'},
     ];
     expectQueued(queue, expected);
   });

--- a/test/unit/gitHubProcessorTests.js
+++ b/test/unit/gitHubProcessorTests.js
@@ -179,7 +179,7 @@ describe('User processing', () => {
       _metadata: { links: {} },
       id: 9,
       repos_url: 'http://repos',
-      events_url: 'https://api.github.com/users/testuser/events',
+      events_url: 'http://events',
     };
 
     const processor = new GitHubProcessor();
@@ -195,7 +195,7 @@ describe('User processing', () => {
 
     const expected = [
       { type: 'repos', url: 'http://repos', qualifier: 'urn:user:9', path: '/repos' },
-      { type: 'events', url: 'https://api.github.com/users/testuser/events', qualifier: 'urn:user:9', path: '/events'},
+      { type: 'events', url: 'http://events', qualifier: 'urn:user:9', path: '/events'},
     ];
     expectQueued(queue, expected);
   });

--- a/test/unit/processingTests.js
+++ b/test/unit/processingTests.js
@@ -19,7 +19,7 @@ describe('Simple processing', () => {
         .then(processOne)
         .then(checkDoc.bind(null, 'org', 'urn:org:1', 4))
         .then(processOne)
-        .then(checkDoc.bind(null, 'user', 'urn:user:1', 1))
+        .then(checkDoc.bind(null, 'user', 'urn:user:1', 2))
         .then(processOne)
         .then(checkDoc.bind(null, 'repos', 'urn:org:1:repos:page:1', 0))
         .then(processOne)
@@ -29,7 +29,7 @@ describe('Simple processing', () => {
         .then(processOne)
         .then(checkDoc.bind(null, 'repos', 'urn:org:1:repos:page:1', 0))
         .then(processOne)
-        .then(checkDoc.bind(null, 'user', 'urn:user:2', 1))  // queued as a member of the org
+        .then(checkDoc.bind(null, 'user', 'urn:user:2', 2))  // queued as a member of the org
         .then(processOne)
         .then(checkDoc.bind(null, 'team', 'urn:team:20', 2))
         .then(processOne)
@@ -133,6 +133,7 @@ const resources = {
       "id": 1,
       "url": "https://api.github.com/users/test",
       "repos_url": "https://api.github.com/users/test/repos",
+      "events_url": "https://api.github.com/users/test/events",
     }
   },
   'https://api.github.com/users/user2': {
@@ -141,6 +142,7 @@ const resources = {
       "id": 2,
       "url": "https://api.github.com/users/user2",
       "repos_url": "https://api.github.com/users/user2/repos",
+      "events_url": "https://api.github.com/users/user2/events",
     }
   },
   'https://api.github.com/users/user2/repos': {


### PR DESCRIPTION
This PR adds functionality to crawl a user's events.
There is one test that is not currently passing. I'd appreciate some help figuring out how to get that last test to pass!

I will also be submitting a PR to https://github.com/microsoft/ghcrawler-cli with instructions on how to use this new functionality with the cli.
I've also added a bit of info to the "Operating" page of the wiki with instructions on how to queue users and will attempt to make a PR to the wiki with those changes as well.